### PR TITLE
Support Ubuntu 18.04

### DIFF
--- a/Convert-food101-model/Dockerfile
+++ b/Convert-food101-model/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu
+FROM ubuntu:18.04
+ARG DEBIAN_FRONTEND=noninteractive
 
 COPY requirements.txt /requirements.txt
 
@@ -9,7 +10,7 @@ RUN apt-get update && apt-get install -y \
     python-pip \
     python-dev \
     ipython \
-    ipython-notebook 
+    jupyter-notebook 
 
 # Install python requirements
 RUN pip install --upgrade pip
@@ -23,4 +24,4 @@ RUN mv food101-model.hdf5 /workspace/
 EXPOSE 8888
 
 # Launch Jupyter notebook
-CMD ["jupyter-notebook","--allow-root", "--ip=0.0.0.0", "--notebook-dir=/workspace"]
+CMD ["jupyter-notebook", "--allow-root", "--ip=0.0.0.0", "--notebook-dir=/workspace"]


### PR DESCRIPTION
As Python 2 ends its lifetime in January 2020, the last Ubuntu LTS, which supports Python script in this repository is 18.04. Therefore I specified the preferred Ubuntu version to 18.04 and changed to use package(s) in this distribution. Also, to prevent a stall by the interactive input of the 'tzdata', set the install sequence to noninteractive mode.